### PR TITLE
Improvements to documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BigRiverJunbi"
 uuid = "6a06b223-7d19-411a-858f-7a319f02fdfd"
 authors = ["Abhirath Anand <74202102+theabhirath@users.noreply.github.com>", "Gregory Farage <faragegr@gmail.com>", "Saunak Sen <sen@uthsc.edu>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ _Statistical Tools for Data Preprocessing (Imputation, Normalization, Transforma
 
 [![CI](https://github.com/senresearch/BigRiverJunbi.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/senresearch/BigRiverJunbi.jl/actions/workflows/CI.yml)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://senresearch.github.io/BigRiverJunbi.jl/stable)
+[![Stable](https://img.shields.io/badge/docs-dev-blue.svg)](https://senresearch.github.io/BigRiverJunbi.jl/dev)
 [![codecov](https://codecov.io/gh/senresearch/BigRiverJunbi.jl/graph/badge.svg?token=FFRLyzBmUd)](https://codecov.io/gh/senresearch/BigRiverJunbi.jl)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BigRiverJunbi.jl
 
-_Statistical Tools for Data Preprocessing (Imputation, Normalization, Transformation)_
+_Data Preparation for 'omics data in Julia_
 
 [![CI](https://github.com/senresearch/BigRiverJunbi.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/senresearch/BigRiverJunbi.jl/actions/workflows/CI.yml)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://senresearch.github.io/BigRiverJunbi.jl/stable)
@@ -10,11 +10,11 @@ _Statistical Tools for Data Preprocessing (Imputation, Normalization, Transforma
 
 ## What is BigRiverJunbi.jl?
 
-BigRiverJunbi.jl is a Julia package for 'omics data preprocessing. While it can be used as a standalone package, it was designed to be used in conjunction with the BigRiverMetabolomics.jl package.
+BigRiverJunbi.jl is a Julia package for 'omics data preprocessing. It provides functions for data imputation, normalization, transformation and standardization.
 
 ### Why the name?
 
-"Junbi" (准备, 준비, 準備) is the word for "preparation" in Chinese, Korean, and Japanese (the pronunciation is slightly different in each of these).
+The word "Junbi" (準備, 준비, 准备) is "preparation" in Chinese, Korean, and Japanese (the pronunciation is slightly different in each of these).
 
 ## Installation
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,11 @@
 [deps]
 BigRiverJunbi = "6a06b223-7d19-411a-858f-7a319f02fdfd"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,17 +22,16 @@ makedocs(;
     ),
     pages = [
         "Home" => "index.md",
+        "Getting Started" => "getting-started.md",
         "API" => [
             "For matrices" => "api.md",
             "For dataframes" => "df-api.md",
-        ]
+        ],
     ]
 )
 
 DocumenterVitepress.deploydocs(;
     repo = "github.com/senresearch/BigRiverJunbi.jl",
-    target = "build",
     devbranch = "main",
-    branch = "gh-pages",
     push_preview = true
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,7 +31,6 @@ DocumenterVitepress.deploydocs(;
     repo = "github.com/senresearch/BigRiverJunbi.jl",
     target = "build",
     devbranch = "main",
-    devurl = "stable",
     branch = "gh-pages",
     push_preview = true
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,8 +22,10 @@ makedocs(;
     ),
     pages = [
         "Home" => "index.md",
-        "Functions for matrices" => "api.md",
-        "Functions for dataframes" => "df-api.md",
+        "API" => [
+            "For matrices" => "api.md",
+            "For dataframes" => "df-api.md",
+        ]
     ]
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,10 +1,22 @@
 # Functions for matrices
 
-```@index
-Pages   = ["api.md"]
-```
+## Imputation
 
 ```@autodocs
 Modules = [BigRiverJunbi]
-Filter = t -> !startswith(string(t), "DataFramesExt")
+Pages = ["impute.jl"]
+```
+
+## Normalization
+
+```@autodocs
+Modules = [BigRiverJunbi]
+Pages = ["normalize.jl"]
+```
+
+## Transformation
+
+```@autodocs
+Modules = [BigRiverJunbi]
+Pages = ["transforms.jl"]
 ```

--- a/docs/src/df-api.md
+++ b/docs/src/df-api.md
@@ -1,11 +1,31 @@
 # Functions for dataframes
 
-These functions are designed to be used in conjunction with the [DataFrames.jl](https://dataframes.juliadata.org/stable/) package. This is part of an extension that can be loaded by simply typing `using DataFrames` in the REPL or your code.
+These functions are designed to be used in conjunction with the [DataFrames.jl](https://dataframes.juliadata.org/stable/) package. Since this is a heavy dependency, DataFrames.jl is not shipped directly with BigRiverJunbi.jl. Instead, this is part of a package extension that can be loaded by installing DataFrames.jl separately and simply typing `using DataFrames` in the REPL or your code before using these functions.
 
-```@index
-Pages   = ["df-api.md"]
-```
+## Imputation
 
 ```@autodocs
 Modules = [Base.get_extension(BigRiverJunbi, :DataFramesExt)]
+Pages = ["ext/DataFramesExt/impute.jl"]
+```
+
+## Normalization
+
+```@autodocs
+Modules = [Base.get_extension(BigRiverJunbi, :DataFramesExt)]
+Pages = ["ext/DataFramesExt/normalize.jl"]
+```
+
+## Transformation
+
+```@autodocs
+Modules = [Base.get_extension(BigRiverJunbi, :DataFramesExt)]
+Pages = ["ext/DataFramesExt/transforms.jl"]
+```
+
+## Utility functions
+
+```@autodocs
+Modules = [Base.get_extension(BigRiverJunbi, :DataFramesExt)]
+Pages = ["ext/DataFramesExt/utils.jl"]
 ```

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,111 @@
+# Getting Started
+
+## Installation
+
+You can install this package from the package mode in the Julia REPL:
+
+```julia
+julia> ] # ']' should be pressed
+pkg> add BigRiverJunbi
+```
+
+Or you can use Julia's package manager `Pkg`:
+
+```julia
+julia> using Pkg
+
+julia> Pkg.add("BigRiverJunbi")
+```
+
+## Generate random data
+
+We generate some random data to demonstrate how this package can be used. This is generated using a lognormal distribution to simulate 'omics data.
+
+```@example 1
+using BigRiverJunbi
+using Random
+using Statistics
+using Missings
+using Distributions
+using Plots, StatsPlots
+gr(); # hide
+
+# Set random seed for reproducibility
+Random.seed!(42)
+
+# Generate sample 'omics data (e.g., metabolomics matrix)
+# Rows = samples, Columns = features
+n_samples, n_features = 50, 20
+data = rand(LogNormal(0, 1), n_samples, n_features)
+
+# Introduce some missing values (simulating real 'omics data)
+missing_indices = rand(1:length(data), 100)  # 100 random missing values
+data_with_missing = Array{Union{Missing, Float64}}(data)
+data_with_missing[missing_indices] .= missing
+
+nothing # hide
+```
+
+## Imputation
+
+Our data will often have missing values. We can impute these using a wide variety of imputation methods that can be found in the API. For this example, we will use the [`BigRiverJunbi.impute_half_min`](@ref) method, which is a simple method that imputes missing values with the half of the minimum non-missing value in the feature.
+
+```@example 1
+# Impute missing values with half of the minimum non-missing value in the feature
+imputed_data = BigRiverJunbi.impute_half_min(data_with_missing)
+
+nothing # hide
+```
+
+We can visualize this data using a heatmap, to see the missing values and the data distribution:
+
+```@example 1
+a = heatmap(data_with_missing, c=:viridis, legend = false)
+b = heatmap(imputed_data, c=:viridis, legend = false)
+plot(a, b, layout = @layout([a b]))
+```
+
+## Normalization
+
+Normalization is a process of scaling the data to a common range. This is often done to account for differences in sample concentrations. For this example, we will use the [`BigRiverJunbi.intnorm`](@ref) method, which is a simple method that normalizes the data to have a total area of 1.
+
+```@example 1
+# disallow missings for imputed data
+imputed_data = disallowmissing(imputed_data)
+# Normalize each sample (row) so total area equals 1
+# This is common in metabolomics to account for dilution effects
+normalized_data = BigRiverJunbi.intnorm(imputed_data; dims = 2)  # dims=2 for row-wise normalization
+
+nothing # hide
+```
+
+## Transformation
+
+Transformation is a process of transforming the data to a different distribution. For this example, we will use the [`BigRiverJunbi.log_tx`](@ref) method, which is a simple method that transforms the data to a log distribution.
+
+```@example 1
+# Log2 transformation with small constant to handle near-zero values
+# Common in 'omics to make data more normally distributed
+transformed_data = BigRiverJunbi.log_tx(normalized_data; base = 2, constant = 1e-6)
+
+nothing # hide
+```
+
+## Standardization
+
+Standardization is a process of scaling the data to have a mean of 0 and a standard deviation of 1. This is often done to account for differences in sample concentrations.
+
+```@example 1
+# Standardize features (columns) to have mean=0 and std=1
+# Essential for many machine learning algorithms
+standardized_data = BigRiverJunbi.standardize(transformed_data; center = true)
+
+nothing # hide
+```
+
+We can now compare the distribution of the first feature of the data before and after the transformation:
+
+```@example 1
+density(imputed_data[:, 1], title="Density plot of the first feature")
+density!(standardized_data[:, 1])
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,13 +9,13 @@ hero:
   actions:
     - theme: brand
       text: Get Started
-      link: /get_started
-    - theme: alt
-      text: View on Github
-      link: https://github.com/senresearch/BigRiverJunbi.jl
+      link: /getting-started
     - theme: alt
       text: API
       link: /api
+    - theme: alt
+      text: View on Github
+      link: https://github.com/senresearch/BigRiverJunbi.jl
 features:
   - title: What is BigRiverJunbi.jl?
     details: BigRiverJunbi.jl is a Julia package for 'omics data preprocessing. It provides functions for data imputation, normalization, transformation and standardization.
@@ -23,25 +23,3 @@ features:
     details: The word &quot;Junbi&quot; (準備, 준비, 准备) is &quot;preparation&quot; in Chinese, Korean, and Japanese (the pronunciation is slightly different in each of these).
 ---
 ```
-
-````@raw html
-<div class="vp-doc" style="width:80%; margin:auto">
-
-<h2> Installation </h2>
-
-You can install BigRiverJunbi using Julia's package manager `Pkg`:
-
-```julia
-julia> using Pkg
-
-julia> Pkg.add("BigRiverJunbi")
-```
-
-Or you can use the package mode in the REPL:
-
-```julia
-] add BigRiverJunbi
-```
-
-</div>
-````

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ layout: home
 
 hero:
   name: "BigRiverJunbi.jl"
-  tagline: Statistical Tools for Data Preprocessing (Imputation, Normalization, Transformation) and Exploratory Analysis for 'omics data in Julia
+  tagline: Data Preparation for 'omics data in Julia
   actions:
     - theme: brand
       text: Get Started
@@ -16,21 +16,16 @@ hero:
     - theme: alt
       text: API
       link: /api
+features:
+  - title: What is BigRiverJunbi.jl?
+    details: BigRiverJunbi.jl is a Julia package for 'omics data preprocessing. It provides functions for data imputation, normalization, transformation and standardization.
+  - title: Why the name?
+    details: The word &quot;Junbi&quot; (準備, 준비, 准备) is &quot;preparation&quot; in Chinese, Korean, and Japanese (the pronunciation is slightly different in each of these).
 ---
 ```
 
 ````@raw html
-<p style="margin-bottom:2cm"></p>
-
 <div class="vp-doc" style="width:80%; margin:auto">
-
-<h1> What is BigRiverJunbi.jl? </h1>
-
-BigRiverJunbi.jl is a Julia package for 'omics data preprocessing. While it can be used as a standalone package, it was designed to be used in conjunction with the BigRiverMetabolomics.jl package.
-
-<h3> Why the name? </h3>
-
-"Junbi" (準備, 준비, 准备) is the word for "preparation" in Chinese, Korean, and Japanese (the pronunciation is slightly different in each of these).
 
 <h2> Installation </h2>
 

--- a/ext/DataFramesExt/impute.jl
+++ b/ext/DataFramesExt/impute.jl
@@ -9,7 +9,7 @@ Replaces missing elements in the specified columns with zero.
 - `start_col`: column index to start imputing from.
 - `end_col`: column index to end imputing at.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> df = DataFrame(A = [1, 2, 3],
@@ -55,7 +55,7 @@ in the corresponding variable.
 - `start_col`: column index to start imputing from.
 - `end_col`: column index to end imputing at.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> df = DataFrame(A = [1, 2, 3],
@@ -129,7 +129,7 @@ non-missing elements in the corresponding variable.
 - `start_col`: column index to start imputing from.
 - `end_col`: column index to end imputing at.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> df = DataFrame(A = [1, 2, 3],
@@ -179,7 +179,7 @@ Returns imputed dataframe based on a categorical imputation:
 - `start_col`: column index to start imputing from.
 - `end_col`: column index to end imputing at.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> df = DataFrame(A = [1, 2, 3],

--- a/ext/DataFramesExt/utils.jl
+++ b/ext/DataFramesExt/utils.jl
@@ -14,7 +14,7 @@ last row and column highlighted.
 # Arguments
 - `df`: The dataframe to add the missing summary to.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> df = DataFrame(A = [1, 2, 3],
@@ -91,7 +91,7 @@ percentage of missing values in the dataframe.
 - `pmissing_rows`: A `Vector` of the percentage of missing values in each row.
 - `total_missing`: The total percentage of missing values in the dataframe.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> df = DataFrame(A = [1, 2, 3],

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -283,7 +283,7 @@ function impute_min_prob!(
     end
     sd_temp = median(sd_vals) * tune_sigma
     # generate data from a normal distribution with the estimated parameters
-    for i in 1:n_samples
+    @views for i in 1:n_samples
         dist = Normal(min_vals[i], sd_temp)
         curr_sample = dims == 1 ? data[:, i] : data[i, :]
         curr_sample_imputed = trycopy(curr_sample)
@@ -528,7 +528,7 @@ function impute_QRILC!(
     )
     # Get dimensions of the data
     n_samples, n_features = size(data)
-    for i in 1:n_samples
+    @views for i in 1:n_samples
         curr_sample = data[:, i]
         # Calculate the percentage of missing values
         pNAs = count(ismissing, curr_sample) / length(curr_sample)

--- a/src/normalize.jl
+++ b/src/normalize.jl
@@ -215,11 +215,7 @@ L(x) = \\begin{cases}
 function huberloss(x::Real; alpha::Real = 1)
     @assert alpha > 0 "Huber crossover parameter alpha must be positive."
     d = abs(x)
-    if d <= alpha
-        return d^2 / 2
-    else
-        return alpha * (d - alpha^2 / 2)
-    end
+    return d <= alpha ? d^2 / 2 : alpha * (d - alpha^2 / 2)
 end
 
 """

--- a/src/normalize.jl
+++ b/src/normalize.jl
@@ -9,7 +9,7 @@ This requires that the matrix has all positive values.
 - `dims`: The dimension to normalize across. Default is 2.
 - `lambda`: The lambda parameter for the normalization. Default is 1.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> mat = [0.5 1 2 3 3.5;
@@ -44,7 +44,7 @@ matrix have all positive values.
 # Arguments
 - `mat`: The matrix to normalize.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> mat = [0.5 1 2 3 3.5;
@@ -89,7 +89,7 @@ that the matrix is organized as samples x features.
 # Arguments
 - `data`: The matrix to normalize.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> mat = [0.5 1 2 3 3.5;
@@ -140,7 +140,7 @@ Performs Huberization for sample intensities.
     values if the MAD is zero. This can be useful if you are expecting this behavior and
     want to handle it yourself, but should be used with caution.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> mat = [0.5 1 2 3 3.5;

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -9,7 +9,7 @@ Default base is 2, default constant is 0.
 - `base`: The base of the logarithm. Default is 2.
 - `constant`: The constant to add to all values. Default is 0.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> mat = [0.5 1 2 3 3.5;
@@ -44,7 +44,7 @@ all positive values.
 - `mat`: The matrix to transform.
 - `dims`: The dimension to mean center across. Default is 1.
 
-# Examples
+# Example
 
 ```jldoctest
 julia> mat = [0.5 1 2 3 3.5;

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,17 +1,12 @@
-"""
-    check_mad(mat::Matrix{<:Real}; dims::Int = 2)
-
-Checks if the MAD (median absolute deviation) is zero for each column of a matrix.
-If it is, then errors and displays the list of columns with zero MAD.
-
-# Arguments
-- `mat`: The matrix to check the MAD for.
-"""
+# Check if the MAD is zero for each column of the matrix. If it is, then errors and
+# displays the list of columns with zero MAD. Can also be used to check each row of a matrix
+# by setting `dims` to 1.
 function check_mad(mat::Matrix{<:Real}; dims::Int = 2)
+    @assert dims in [1, 2] "dims must be 1 or 2"
     error_cols = String[]
     for i in axes(mat, dims)
         try
-            check_mad(mat[:, i])
+            dims == 2 ? check_mad(mat[:, i]) : check_mad(mat[i, :])
         catch
             push!(error_cols, string(i))
         end
@@ -29,14 +24,7 @@ function check_mad(mat::Matrix{<:Real}; dims::Int = 2)
     end
 end
 
-"""
-    check_mad(x::Vector{<:Real})
-
-Checks if the MAD (median absolute deviation) is zero for a vector. If it is, then errors.
-
-# Arguments
-- `x`: The vector to check the MAD for.
-"""
+# Checks if the MAD (median absolute deviation) is zero for a vector. If it is, then errors.
 function check_mad(x::Vector{<:Real})
     s = mad(x; normalize = true)
     return if s == 0

--- a/test/normalize.jl
+++ b/test/normalize.jl
@@ -91,7 +91,7 @@ end
     @test size(result_single_col) == (3, 1)
 
     # Test that ranks are preserved within each feature (column)
-    for j in axes(mat, 2)
+    @views for j in axes(mat, 2)
         original_ranks = sortperm(mat[:, j])
         result_ranks = sortperm(result[:, j])
         @test original_ranks == result_ranks


### PR DESCRIPTION
This PR aims to bring more consistent and helpful documentation to BigRiverJunbi.jl, and also adopt a format that can be used for BigRiverMakie.jl and BigRiverMetabolomics.jl.

- [x] Make the navigation cleaner
- [x] Separate out headings under API reference
- [x] Add a "getting started" tutorial explaining to a new user how to use the package