### PR TITLE
Dev

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BigRiverJunbi"
 uuid = "6a06b223-7d19-411a-858f-7a319f02fdfd"
 authors = ["Abhirath Anand <74202102+theabhirath@users.noreply.github.com>", "Gregory Farage", "Saunak Sen"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -535,7 +535,7 @@ function impute_QRILC!(
         # Estimate the mean and standard deviation of the original
         # distribution using quantile regression
         upper_q = 0.99
-        q_normal = map(Base.Fix1(quantile, Normal(0, 1)), LinRange(pNAs + eps, upper_q + eps, 100))
+        q_normal = quantile(Normal(0, 1), LinRange(pNAs + eps, upper_q + eps, 100))
         q_curr_sample = quantile(skipmissing(curr_sample), LinRange(eps, upper_q + eps, 100))
         temp_QR = lm(hcat(ones(length(q_normal), 1), reshape(q_normal, :, 1)), q_curr_sample)
         # get the coefficients of the quantile regression

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -581,18 +581,7 @@ function impute_QRILC!(
     data = transpose_data ? permutedims(data) : data
   
     # Optional: log-transform in place on non-missing entries
-    if log_transform
-        @inbounds for j in 1:size(data, 2), i in 1:size(data, 1)
-            v = data[i, j]
-            if !ismissing(v)
-                s = v + log_offset
-                if !(s > 0)
-                    throw(ArgumentError("log_transform=true requires x + log_offset > 0; got $(v) at ($i,$j). Increase log_offset."))
-                end
-                data[i, j] = log(s)
-            end
-        end
-    end
+    log_transform && log_tx!(data; log_offset)
 
     # Get dimensions of the data
     n_rows, m_cols = size(data)
@@ -625,14 +614,7 @@ function impute_QRILC!(
     end
 
     # Invert log transform
-    if log_transform
-        @inbounds for j in 1:size(data, 2), i in 1:size(data, 1)
-            v = data[i, j]
-            if !ismissing(v)
-                data[i, j] = exp(v) - log_offset
-            end
-        end
-    end
+    log_transform && log_tx_inv!(data; log_offset)
 
     # Transpose data back if it was transposed
     data = transpose_data ? permutedims(data) : data
@@ -640,7 +622,41 @@ function impute_QRILC!(
     return data
 end
 
-### TODO: add docstrings for the SVD imputation methods
+"""
+        imputeSVD(
+                data::AbstractMatrix{<:Union{Missing, Real}};
+                rank::Union{Nothing, Int} = nothing,
+                tol::Float64 = 1.0e-10,
+                maxiter::Int = 100,
+                limits::Union{Tuple{Float64, Float64}, Nothing} = nothing,
+                dims::Union{Nothing, Int} = nothing,
+                verbose::Bool = true
+        )
+
+Return a copy of `data` with missing values imputed by an iterative low-rank SVD
+approximation.
+
+# Arguments
+- `data`: Matrix of observations that may contain `missing` entries.
+- `rank`: Target rank of the reconstruction. If `nothing`, the method starts at rank 0
+    and increases it by one per iteration up to `min(size(data)...) - 1`.
+- `tol`: Convergence tolerance on the relative squared difference of the imputed entries.
+- `maxiter`: Maximum number of SVD refinements.
+- `limits`: Optional `(lo, hi)` bounds; imputed values are clamped to this range each
+    iteration when provided.
+- `dims`: Dimension passed to [`substitute!`](@ref) for the initial median fill. Use `1` to
+    substitute column-wise medians, `2` for row-wise medians, or `nothing` to use the entire
+    matrix.
+- `verbose`: When `true`, emits `@debug` diagnostics for each iteration (diff, MAE,
+    convergence ratio).
+
+# Returns
+`Matrix{Union{Missing, Float64}}` with the same size as `data`, where the `missing` entries
+have been replaced by the fitted low-rank approximation.
+
+# Notes
+The original `data` is left unchanged.
+"""
 function imputeSVD(
         data::AbstractMatrix{<:Union{Missing, Real}};
         rank::Union{Nothing, Int} = nothing,
@@ -654,6 +670,41 @@ function imputeSVD(
     return imputeSVD!(trycopy(promoted); rank, tol, maxiter, limits, dims, verbose)
 end
 
+"""
+    imputeSVD!(
+        data::AbstractMatrix{Union{Missing, Float64}};
+        rank::Union{Nothing, Int},
+        tol::Float64,
+        maxiter::Int,
+        limits::Union{Tuple{Float64, Float64}, Nothing},
+        dims::Union{Nothing, Int},
+        verbose::Bool
+    )
+
+Mutate `data` in place by replacing missing values with an iterative low-rank SVD
+reconstruction.
+
+# Arguments
+- `data`: Matrix whose elements are `Union{Missing, Float64}`. The matrix is overwritten as
+    the algorithm converges.
+- `rank`: Desired rank of the approximation. If `nothing`, the rank is incremented each
+    iteration up to `min(size(data)...) - 1`.
+- `tol`: Convergence tolerance based on the ratio of squared differences between the
+    previous and current imputations on missing entries.
+- `maxiter`: Maximum number of SVD updates.
+- `limits`: Optional `(lo, hi)` bounds applied with `clamp!` after each reconstruction.
+- `dims`: Dimension forwarded to [`substitute!`](@ref) when computing the initial median
+    replacement of missings.
+- `verbose`: When `true`, emits `@debug` logs summarizing diagnostics for the initial state
+    and each iteration.
+
+# Returns
+The mutated `data` matrix with missing values imputed.
+
+# Notes
+Call [`imputeSVD`](@ref) to use the same algorithm with sensible defaults for the keyword
+arguments while leaving the original data untouched.
+"""
 function imputeSVD!(
         data::AbstractMatrix{Union{Missing, Float64}};
         rank::Union{Nothing, Int},

--- a/src/impute.jl
+++ b/src/impute.jl
@@ -466,15 +466,22 @@ end
 
 """
     impute_QRILC(
-        data::Matrix{<:Union{Missing, Real}};
-        tune_sigma::Float64 = 1.0,
-        eps::Float64 = 0.005
+        data::Matrix{Union{Missing, Float64}};
+        tune_sigma::Float64 = 1.0, 
+        transpose_data::Bool = false,
+        log_transform::Bool = true,
+        log_offset::Float64 = 0.0,
+        delta::Float64 = 0.001,
+        upper_q::Float64 = 0.99,
+        rng::AbstractRNG = Random.default_rng()
     )
 
 Returns imputated matrix based on the "Quantile regression Imputation for left-censored
-data" (QRILC) method. The function is based on the function `impute.QRILC` from the
-`imputeLCMD` R package, with one difference: the default value of `eps` is set to 0.005
-instead of 0.001.
+data" (QRILC) method. Writes the result back to the original matrix. The function is based on
+the function `impute.QRILC` from the `imputeLCMD` R package.
+
+**Imputation is performed column-wise** (one sample at a time). The **recommended layout** is
+**samples in columns** and **features in rows** (i.e., each column is a sample).
 
 # Arguments
 
@@ -484,30 +491,55 @@ instead of 0.001.
                 - 1 if the complete data distribution is supposed to be gaussian.
                 - 0 < tune_sigma < 1 if the complete data distribution is supposed to be
                   left-censored.
-  Default is 1.0.
-- `eps`: small value added to the quantile for stability.
+- `transpose_data`: if `true`, transpose before imputation and transpose back before returning.
+- `log_transform`: if `true`, apply log(+offset) pre-imputation and invert post-imputation (default is `true``).
+- `log_offset`: constant added inside the log; set > 0 if your data can be ≤ 0 (e.g., zeros) (default is `0.0`).
+- `delta`: small offset, for numerical stability, that prevents edge-case errors when using
+         probabilities that are too close to 0 or 1. Default is 0.001.
+- `upper_q`: Upper probability limit used when fitting the quantile regression (default `0.99`).         
 - `rng`: random number generator. Default is `Random.default_rng()`.
+
+## Notes
+The method estimates a latent left-censored Normal(μ, σ) per column by regressing empirical
+quantiles of the observed values on standard-normal quantiles, then imputes missings by drawing
+from a Normal(μ, σ·tune_sigma) truncated above at the (p_missing + delta) quantile.
 """
 function impute_QRILC(
-        data::Matrix{<:Union{Missing, Real}};
-        tune_sigma = 1.0, eps = 0.005,
+        data::Matrix{<:Union{Missing, Float64}};
+        tune_sigma = 1.0, 
+        transpose_data::Bool = false,
+        log_transform::Bool = true,
+        log_offset::Float64 = 0.0,
+        delta = 0.005,
+        upper_q = 0.99,
         rng::AbstractRNG = Random.default_rng()
     )
     promoted = convert(Matrix{Union{Missing, Float64}}, data)
-    return impute_QRILC!(trycopy(promoted); tune_sigma, eps, rng)
+    return impute_QRILC!(
+            trycopy(promoted); tune_sigma, transpose_data, log_transform, 
+            log_offset, delta, upper_q, rng
+        )
 end
+
 
 """
     impute_QRILC!(
         data::Matrix{Union{Missing, Float64}};
-        tune_sigma::Float64 = 1.0, eps::Float64 = 0.005,
+        tune_sigma::Float64 = 1.0, 
+        transpose_data::Bool = false,
+        log_transform::Bool = true,
+        log_offset::Float64 = 0.0,
+        delta::Float64 = 0.001,
+        upper_q::Float64 = 0.99,
         rng::AbstractRNG = Random.default_rng()
     )
 
-Imputes missing elements based on the "Quantile regression Imputation for left-censored
+Imputes, in place, missing elements based on the "Quantile regression Imputation for left-censored
 data" (QRILC) method. Writes the result back to the original matrix. The function is based on
-the function `impute.QRILC` from the `imputeLCMD` R package, with one difference: the
-default value of `eps` is set to 0.005 instead of 0.001.
+the function `impute.QRILC` from the `imputeLCMD` R package.
+
+**Imputation is performed column-wise** (one sample at a time). The **recommended layout** is
+**samples in columns** and **features in rows** (i.e., each column is a sample).
 
 # Arguments
 
@@ -517,40 +549,94 @@ default value of `eps` is set to 0.005 instead of 0.001.
                 - 1 if the complete data distribution is supposed to be gaussian.
                 - 0 < tune_sigma < 1 if the complete data distribution is supposed to be
                   left-censored.
-- `eps`: small value added to the quantile for stability.
+- `transpose_data`: if `true`, transpose before imputation and transpose back before returning.
+- `log_transform`: if `true`, apply log(+offset) pre-imputation and invert post-imputation (default is `true``).
+- `log_offset`: constant added inside the log; set > 0 if your data can be ≤ 0 (e.g., zeros) (default is `0.0`).
+- `delta`: small offset, for numerical stability, that prevents edge-case errors when using
+         probabilities that are too close to 0 or 1. Default is 0.001.
+- `upper_q`: Upper probability limit used when fitting the quantile regression (default `0.99`).         
 - `rng`: random number generator. Default is `Random.default_rng()`.
+
+## Notes
+The method estimates a latent left-censored Normal(μ, σ) per column by regressing empirical
+quantiles of the observed values on standard-normal quantiles, then imputes missings by drawing
+from a Normal(μ, σ·tune_sigma) truncated above at the (p_missing + delta) quantile.
+
 """
-# TODO: elaborate on eps and why it is set to 0.005
 function impute_QRILC!(
         data::Matrix{<:Union{Missing, Float64}};
-        tune_sigma = 1.0, eps = 0.005,
+        tune_sigma = 1.0, 
+        transpose_data::Bool = false,
+        log_transform::Bool = true,
+        log_offset::Float64 = 0.0,
+        delta = 0.005,
+        upper_q = 0.99,
         rng::AbstractRNG = Random.default_rng()
     )
+    @assert 0 < tune_sigma <= 1 "tune_sigma must be between 0 and 1"
+    @assert 0 < delta < 1 "delta must be between 0 and 1"
+    @assert 0 < upper_q < 1 "upper_q must be between 0 and 1"
+    
+    # Transpose data if necessary
+    data = transpose_data ? permutedims(data) : data
+  
+    # Optional: log-transform in place on non-missing entries
+    if log_transform
+        @inbounds for j in 1:size(data, 2), i in 1:size(data, 1)
+            v = data[i, j]
+            if !ismissing(v)
+                s = v + log_offset
+                if !(s > 0)
+                    throw(ArgumentError("log_transform=true requires x + log_offset > 0; got $(v) at ($i,$j). Increase log_offset."))
+                end
+                data[i, j] = log(s)
+            end
+        end
+    end
+
     # Get dimensions of the data
-    n_samples, n_features = size(data)
-    @views for i in 1:n_samples
+    n_rows, m_cols = size(data)
+    
+    @views for i in 1:m_cols
         curr_sample = data[:, i]
         # Calculate the percentage of missing values
         pNAs = count(ismissing, curr_sample) / length(curr_sample)
+
         # Estimate the mean and standard deviation of the original
         # distribution using quantile regression
-        upper_q = 0.99
-        q_normal = quantile(Normal(0, 1), LinRange(pNAs + eps, upper_q + eps, 100))
-        q_curr_sample = quantile(skipmissing(curr_sample), LinRange(eps, upper_q + eps, 100))
+        q_normal = quantile(Normal(0, 1), LinRange(pNAs + delta, upper_q + delta, 100))
+        q_curr_sample = quantile(skipmissing(curr_sample), LinRange(eps, upper_q + delta, 100))
         temp_QR = lm(hcat(ones(length(q_normal), 1), reshape(q_normal, :, 1)), q_curr_sample)
-        # get the coefficients of the quantile regression
+        # Get the coefficients of the quantile regression
         coefs = coef(temp_QR)
+        # Get the mean and standard deviation of the censured (left-censored) data distribution
         mean_CDD, sd_CDD = coefs[1], abs(coefs[2])
-        # generate data from a truncated normal distribution with the estimated parameters
+        
+        # Generate data from a truncated normal distribution with the estimated parameters
         truncated_dist = truncated(
             Normal(mean_CDD, sd_CDD * tune_sigma);
-            upper = quantile(Normal(mean_CDD, sd_CDD), pNAs + eps)
+            upper = quantile(Normal(mean_CDD, sd_CDD), pNAs + delta)
         )
+        # Fill missing values with random draws from the truncated normal distribution
         curr_sample_imputed = trycopy(curr_sample)
         missing_idx = findall(ismissing, curr_sample)
-        curr_sample_imputed[missing_idx] .= rand(rng, truncated_dist, n_features)[missing_idx]
+        curr_sample_imputed[missing_idx] .= rand(rng, truncated_dist, n_rows)[missing_idx]
         data[:, i] = curr_sample_imputed
     end
+
+    # Invert log transform
+    if log_transform
+        @inbounds for j in 1:size(data, 2), i in 1:size(data, 1)
+            v = data[i, j]
+            if !ismissing(v)
+                data[i, j] = exp(v) - log_offset
+            end
+        end
+    end
+
+    # Transpose data back if it was transposed
+    data = transpose_data ? permutedims(data) : data
+  
     return data
 end
 

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -1,13 +1,13 @@
 """
-    log_tx(mat::Matrix{<:Real}; base::Real = 2, constant::Real = 0)
+    log_tx(mat::Matrix{<:Real}; base::Real = exp(1), log_offset::Real = 0.0)
 
-Computes logarithm on a matrix, adding a constant to all values (for instance, to avoid log(0)).
-Default base is 2, default constant is 0.
+Compute the logarithm of `mat`, adding `log_offset` to all values (for instance, to avoid
+`log(0)`). Returns a new matrix without modifying the original.
 
 # Arguments
 - `mat`: The matrix to transform.
-- `base`: The base of the logarithm. Default is 2.
-- `constant`: The constant to add to all values. Default is 0.
+- `base`: The base of the logarithm. Default is `exp(1)`.
+- `log_offset`: The constant to add to all values. Default is `0.0`.
 
 # Example
 
@@ -20,19 +20,233 @@ julia> mat = [0.5 1 2 3 3.5;
  7.0  3.0  5.0  0.0  3.5
  8.0  2.0  5.0  6.0  0.0
 
-julia> BigRiverJunbi.log_tx(mat; constant = 1)
+julia> BigRiverJunbi.log_tx(mat; log_offset = 1)
 3×5 Matrix{Float64}:
  0.584963  1.0      1.58496  2.0      2.16993
  3.0       2.0      2.58496  0.0      2.16993
  3.16993   1.58496  2.58496  2.80735  0.0
+
+ ---
+
+  log_tx(data::AbstractMatrix{<:Union{Missing, Real}};
+        base::Real = exp(1),
+        log_offset::Real = 0.0)
+
+Apply a logarithmic transform to the non-missing entries of `data`
+after shifting by `log_offset`. Returns the log transformed `data`.
+
+# Arguments
+- `data`: Matrix-like container mutated in place.
+- `base`: The base of the logarithm. Default is `exp(1)`.
+- `log_offset`: Constant added prior to taking the logarithm. Must ensure `x + log_offset > 0`.
+
+# Throws
+- `ArgumentError` if a non-missing entry violates `x + log_offset > 0`.
+
+
 ```
 """
-function log_tx(mat::Matrix{<:Real}; base::Real = 2, constant::Real = 0)
-    mat = mat .+ constant
-    @assert all(mat .> 0) "Matrix has non-positive values even after adding constant. Please" *
-        " remove such values before transforming."
-    return log.(base, mat)
+function log_tx(
+        data::AbstractMatrix{<:Real};
+        base::Real = 2,
+        log_offset::Real = 0.0
+    )
+    result = copy(data)
+    return log_tx!(result; base = base, log_offset = log_offset)
 end
+
+function log_tx(
+        data::AbstractMatrix{<:Union{Missing, Real}};
+        base::Real = 2,
+        log_offset::Real = 0.0
+    )
+    result = copy(data)
+    return log_tx!(result; base = base, log_offset = log_offset)
+end
+
+
+"""
+log_tx(mat::Matrix{<:Real}; base::Real = exp(1), log_offset::Real = 0.0)
+
+Apply an in-place logarithmic transform after shifting by `log_offset`.
+
+# Arguments
+- `mat`: The matrix to transform.
+- `base`: The base of the logarithm. Default is `exp(1)`.
+- `log_offset`: The constant to add to all values. Default is `0.0`.
+
+# Example
+
+```jldoctest
+julia> mat = [0.5 1 2 3 3.5;
+             7 3 5 0 3.5;
+             8 2 5 6 0]
+3×5 Matrix{Float64}:
+ 0.5  1.0  2.0  3.0  3.5
+ 7.0  3.0  5.0  0.0  3.5
+ 8.0  2.0  5.0  6.0  0.0
+
+julia> BigRiverJunbi.log_tx(mat; log_offset = 1)
+3×5 Matrix{Float64}:
+ 0.584963  1.0      1.58496  2.0      2.16993
+ 3.0       2.0      2.58496  0.0      2.16993
+ 3.16993   1.58496  2.58496  2.80735  0.0
+
+julia> mat
+3×5 Matrix{Float64}:
+ 0.584963  1.0      1.58496  2.0      2.16993
+ 3.0       2.0      2.58496  0.0      2.16993
+ 3.16993   1.58496  2.58496  2.80735  0.0
+
+ ---
+
+  log_tx!(data::AbstractMatrix{<:Union{Missing, Real}};
+        base::Real = exp(1),
+        log_offset::Real = 0.0)
+
+Apply an in-place logarithmic transform after shifting by `log_offset`. For matrices that may
+contain `missing`, only the non-missing entries are transformed.
+
+# Arguments
+- `data`: Matrix-like container mutated in place.
+- `base`: The base of the logarithm. Default is `exp(1)`.
+- `log_offset`: Constant added prior to taking the logarithm. Must ensure `x + log_offset > 0`.
+
+# Throws
+- `ArgumentError` if a non-missing entry violates `x + log_offset > 0`.
+
+Returns the mutated `data`.
+"""
+function log_tx!(
+        data::Matrix{<:Real};
+        base::Real = exp(1),
+        log_offset::Real = 0.0
+    )
+    b = float(base)
+    if !(b > 0) || b == 1
+        throw(ArgumentError("`base` must be > 0 and ≠ 1; got $base"))
+    end
+
+    @inbounds for j in axes(data, 2), i in axes(data, 1)
+        s = data[i, j] + log_offset
+        if !(s > 0)
+            throw(
+                ArgumentError(
+                    "log_tx! requires x + log_offset > 0; got $(data[i, j]) at ($(i),$(j)). Increase log_offset."
+                )
+            )
+        end
+        data[i, j] = log(b, s)
+    end
+
+    return data
+end
+
+
+function log_tx!(
+        data::AbstractMatrix{<:Union{Missing, Real}};
+        base::Real = exp(1),
+        log_offset::Real = 0.0
+    )
+
+    # validate base
+    b = float(base)
+    if !(b > 0) || b == 1
+        throw(ArgumentError("`base` must be > 0 and ≠ 1; got $base"))
+    end
+
+    @inbounds for j in axes(data, 2), i in axes(data, 1)
+        v = data[i, j]
+        if !ismissing(v)
+            s = v + log_offset
+            if !(s > 0)
+                throw(
+                    ArgumentError(
+                        "log_tx! requires x + log_offset > 0; got $(v) at ($(i),$(j)). Increase log_offset."
+                    )
+                )
+            end
+            data[i, j] = log(base, s)
+        end
+    end
+
+    return data
+end
+
+
+"""
+    log_tx_inv(mat::Matrix{<:Real}; base::Real = exp(1), log_offset::Real = 0.0)
+
+Undo [`log_tx`](@ref) by exponentiating each entry in `mat` (with respect to `base`) and
+subtracting `log_offset`. Returns a new matrix, leaving `mat` unchanged.
+"""
+function log_tx_inv(
+        mat::Matrix{<:Real};
+        base::Real = exp(1),
+        log_offset::Real = 0.0
+    )
+    result = copy(mat)
+    return log_tx_inv!(result; base = base, log_offset = log_offset)
+end
+
+function log_tx_inv(
+        data::AbstractMatrix{<:Union{Missing, Real}};
+        base::Real = exp(1),
+        log_offset::Real = 0.0
+    )
+    result = copy(data)
+    return log_tx_inv!(result; base = base, log_offset = log_offset)
+end
+
+"""
+    log_tx_inv!(data::Matrix{<:Real}; base::Real = exp(1), log_offset::Real = 0.0)
+
+In-place inverse of [`log_tx!`](@ref) for matrices without `missing` values.
+"""
+function log_tx_inv!(
+        data::Matrix{<:Real};
+        base::Real = exp(1),
+        log_offset::Real = 0.0
+    )
+    b = float(base)
+    if !(b > 0) || b == 1
+        throw(ArgumentError("`base` must be > 0 and ≠ 1; got $base"))
+    end
+    log_b = log(b)
+
+    @inbounds for j in axes(data, 2), i in axes(data, 1)
+        data[i, j] = exp(log_b * data[i, j]) - log_offset
+    end
+
+    return data
+end
+
+"""
+    log_tx_inv!(data::AbstractMatrix{<:Union{Missing, Real}}; base::Real = exp(1), log_offset::Real = 0.0)
+
+In-place inverse of [`log_tx!`](@ref) that skips entries equal to `missing`.
+"""
+function log_tx_inv!(
+        data::AbstractMatrix{<:Union{Missing, Real}};
+        base::Real = exp(1),
+        log_offset::Real = 0.0
+    )
+    b = float(base)
+    if !(b > 0) || b == 1
+        throw(ArgumentError("`base` must be > 0 and ≠ 1; got $base"))
+    end
+    log_b = log(b)
+
+    @inbounds for j in axes(data, 2), i in axes(data, 1)
+        v = data[i, j]
+        if !ismissing(v)
+            data[i, j] = exp(log_b * v) - log_offset
+        end
+    end
+
+    return data
+end
+
 
 """
     meancenter_tx(mat::Matrix{Float64}, dims::Int64 = 1)

--- a/test/transforms.jl
+++ b/test/transforms.jl
@@ -11,7 +11,7 @@
     ]
 
     # Test with constant to avoid log(0)
-    result = BigRiverJunbi.log_tx(mat; constant = 1)
+    result = BigRiverJunbi.log_tx(mat; log_offset = 1)
     expected = [
         0.584963 1.0 1.58496 2.0 2.16993;
         3.0 2.0 2.58496 0.0 2.16993;
@@ -48,7 +48,7 @@ end
 
     # Test error with negative values even after adding constant
     mat_negative = [-2.0 1.0; 3.0 -1.0]
-    @test_throws AssertionError BigRiverJunbi.log_tx(mat_negative; constant = 1)
+    @test_throws AssertionError BigRiverJunbi.log_tx(mat_negative; log_offset = 1)
 
     # Test error with zero values and no constant
     mat_with_zeros = [0.0 1.0; 2.0 3.0]
@@ -60,7 +60,7 @@ end
 
     # Test error when constant is insufficient
     mat_very_negative = [-5.0 1.0; 2.0 -3.0]
-    @test_throws AssertionError BigRiverJunbi.log_tx(mat_very_negative; constant = 2)
+    @test_throws AssertionError BigRiverJunbi.log_tx(mat_very_negative; log_offset = 2)
 
     # Test behavior with invalid base
     mat_positive = [1.0 2.0; 3.0 4.0]
@@ -87,7 +87,7 @@ end
 
     # Test with large constant
     mat_small = [0.1 0.2; 0.3 0.4]
-    result_large_constant = BigRiverJunbi.log_tx(mat_small; constant = 100)
+    result_large_constant = BigRiverJunbi.log_tx(mat_small; log_offset = 100)
     expected_large_constant = log.(2, mat_small .+ 100)
     @test result_large_constant ≈ expected_large_constant
 
@@ -104,9 +104,66 @@ end
 
     # Test with very small positive values
     mat_tiny = [1.0e-10 1.0e-5; 1.0e-3 1.0]
-    result_tiny = BigRiverJunbi.log_tx(mat_tiny; constant = 0)
+    result_tiny = BigRiverJunbi.log_tx(mat_tiny; log_offset = 0)
     # Should not throw error since all values are positive
     @test all(isfinite.(result_tiny))
+end
+
+@testitem "log_tx with missing values" begin
+    using Test
+    using BigRiverJunbi
+
+    mat = Union{Missing, Float64}[1.0 missing; 3.0 5.0]
+    mat_copy = copy(mat)
+    result = BigRiverJunbi.log_tx(mat; base = ℯ, log_offset = 1.0)
+
+    @test isequal(mat, mat_copy)  # non-mutating
+    @test result !== mat  # returns new matrix
+    @test result[1, 1] ≈ log(ℯ, 2.0)
+    @test result[2, 1] ≈ log(ℯ, 4.0)
+    @test result[2, 2] ≈ log(ℯ, 6.0)
+    @test ismissing(result[1, 2])
+
+    mat_bad = Union{Missing, Float64}[missing -0.5; 0.0 1.0]
+    @test_throws ArgumentError BigRiverJunbi.log_tx(mat_bad; log_offset = 0.0)
+end
+
+@testitem "log_tx! in-place real matrices" begin
+    using Test
+    using BigRiverJunbi
+
+    mat = [1.0 2.0; 4.0 8.0]
+    BigRiverJunbi.log_tx!(mat; base = 2, log_offset = 0.0)
+    @test mat ≈ [0.0 1.0; 2.0 3.0]
+
+    mat = [0.1 1.0; 2.0 3.0]
+    @test_throws ArgumentError BigRiverJunbi.log_tx!(mat; log_offset = 0.0)
+
+    mat = [0.1 1.0; 2.0 3.0]
+    mat_copy = copy(mat)
+    BigRiverJunbi.log_tx!(mat; log_offset = 1.0)
+    @test mat ≈ log.(ℯ, mat_copy .+ 1.0)
+end
+
+@testitem "log_tx_inv round trip" begin
+    using Test
+    using BigRiverJunbi
+
+    mat = [0.25 1.5; 4.0 8.0]
+    transformed = BigRiverJunbi.log_tx(mat; base = 2, log_offset = 0.75)
+    restored = BigRiverJunbi.log_tx_inv(transformed; base = 2, log_offset = 0.75)
+    @test restored ≈ mat
+
+    mat_miss = Union{Missing, Float64}[missing 1.0; 2.5 missing]
+    transformed_miss = BigRiverJunbi.log_tx(mat_miss; log_offset = 0.5)
+    restored_miss = BigRiverJunbi.log_tx_inv(transformed_miss; log_offset = 0.5)
+    @test isequal(restored_miss, mat_miss)
+
+    # Mutating inverse
+    mat_roundtrip = copy(mat)
+    BigRiverJunbi.log_tx!(mat_roundtrip; base = 2, log_offset = 0.75)
+    BigRiverJunbi.log_tx_inv!(mat_roundtrip; base = 2, log_offset = 0.75)
+    @test mat_roundtrip ≈ mat
 end
 
 @testitem "meancenter_tx basic functionality" begin


### PR DESCRIPTION
- changed q_normal in impute QRILC with a vectorized call, computing everything in one shot, and more efficient & idiomatic
- changed eps into delta, added transpose and log transform option in impute_QRILC, fixed issue for loop range indexes
- updated log transform function when matrix contains missing values, proposed a documentation for SVD imputation